### PR TITLE
Fix first file detection in installation script

### DIFF
--- a/deployments/kubernetes/install/scripts/install-cni.sh
+++ b/deployments/kubernetes/install/scripts/install-cni.sh
@@ -141,7 +141,7 @@ sed -i s~__KUBECONFIG_FILEPATH__~${HOST_CNI_NET_DIR}/istio-cni-kubeconfig~g $TMP
 sed -i s~__LOG_LEVEL__~${LOG_LEVEL:-warn}~g $TMP_CONF
 
 # default to first file in `ls` output
-CNI_CONF_NAME=${CNI_CONF_NAME:-$(ls | head -n 1)}
+CNI_CONF_NAME=${CNI_CONF_NAME:-$(ls -1 /host/etc/cni/net.d/ | grep -v 'istio-cni-kubeconfig' | head -n 1)}
 CNI_CONF_NAME=${CNI_CONF_NAME:-10-calico.conflist}
 CNI_OLD_CONF_NAME=${CNI_OLD_CONF_NAME:-${CNI_CONF_NAME}}
 


### PR DESCRIPTION
This PR ensures that the first configuration file is located from within the `/host/etc/cni/net.d/` directory, and that it also ignores any files containing `istio-cni-kubeconfig` in their name.

Fixes #12.

Signed-off-by: Venil Noronha <veniln@vmware.com>