### PR TITLE
Update check-tree path matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@
 #-----------------------------------------------------------------------------
 # Global Variables
 #-----------------------------------------------------------------------------
-ISTIO_CNI_RELPATH ?= github.com/tiswanso/istio-cni
-#ISTIO_CNI_RELPATH ?= github.com/tiswanso/istio-cni
+ISTIO_CNI_RELPATH ?= istio.io/cni
 
 ISTIO_GO := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 export ISTIO_GO

--- a/README.md
+++ b/README.md
@@ -119,10 +119,23 @@ $ oc adm policy add-scc-to-user privileged -z istio-cni -n kube-system
 
 ## Build
 
+First, clone this repository under `$GOPATH/src/istio.io/`.
+
 For linux targets:
 
-```
+```sh
 $ GOOS=linux make build
+```
+
+You can also build the project from a non-standard location like so:
+
+```sh
+$ ISTIO_CNI_RELPATH=github.com/some/cni GOOS=linux make build
+```
+
+To push the Docker image:
+
+```sh
 $ export HUB=docker.io/tiswanso
 $ export TAG=dev
 $ GOOS=linux make docker.push


### PR DESCRIPTION
This PR updates `ISTIO_CNI_RELPATH` to `istio.io/cni` in order to enforce a standard location for the Istio CNI plugin.

Fixes #16.

Signed-off-by: Venil Noronha <veniln@vmware.com>