### PR TITLE
fix k8sArgs & make circleci use go 1.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,11 @@ initWorkingDir: &initWorkingDir
     mkdir -p /go/out/tests
     mkdir -p /go/out/logs
     mkdir -p /home/circleci/logs
+    # TODO - temporary until 'machine' image is updated or customized
+    GOROOT=$(go env GOROOT)
+    sudo rm -r $(go env GOROOT)
+    sudo mkdir $GOROOT
+    curl https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz | sudo tar xz -C $GOROOT --strip-components=1
 
 jobs:
   build:

--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -217,10 +217,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 			if k8sErr != nil {
 				logger.Warnf("Error geting Pod data %v", k8sErr)
 			}
-			//for _, container := range containers {
-			//if container == "istio-proxy" {
 			logger.Infof("Found containers %v", containers)
-			if len(containers) >= 1 {
+			if len(containers) > 1 {
 				logrus.WithFields(logrus.Fields{
 					"ContainerID": args.ContainerID,
 					"netns":       args.Netns,
@@ -228,12 +226,12 @@ func cmdAdd(args *skel.CmdArgs) error {
 					"Namespace":   string(k8sArgs.K8S_POD_NAMESPACE),
 					"ports":       ports,
 					"annotations": annotations,
-				}).Infof("Updating iptables redirect for Istio proxy")
+				}).Infof("Checking annotations prior to redirect for Istio proxy")
 				if val, ok := annotations[injectAnnotationKey]; ok {
 					logrus.Infof("Pod %s contains inject annotation: %s", string(k8sArgs.K8S_POD_NAME), val)
-					if b, err := strconv.ParseBool(val); err == nil {
-						if !b {
-							logrus.Infof("Pod excluded due to annotations")
+					if injectEnabled, err := strconv.ParseBool(val); err == nil {
+						if !injectEnabled {
+							logrus.Infof("Pod excluded due to inject-disabled annotation")
 							excludePod = true
 						}
 					}
@@ -243,8 +241,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 					_ = setupRedirect(args.Netns, ports)
 				}
 			}
-			//}
-			//}
 		} else {
 			logger.Infof("Pod excluded")
 		}

--- a/cmd/istio-cni/main.go
+++ b/cmd/istio-cni/main.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -41,6 +42,7 @@ var (
 	redirectIPCidr        = "*"
 	redirectExcludeIPCidr = ""
 	redirectExcludePort   = "15020"
+	injectAnnotationKey   = "sidecar.istio.io/inject"
 )
 
 // Kubernetes a K8s specific struct to hold config
@@ -77,12 +79,13 @@ type PluginConf struct {
 }
 
 // K8sArgs is the valid CNI_ARGS used for Kubernetes
+// The field names need to match exact keys in kubelet args for unmarshalling
 type K8sArgs struct {
 	types.CommonArgs
-	IP                   net.IP
-	K8sPodName           types.UnmarshallableString
-	K8sPodNamespace      types.UnmarshallableString
-	K8sPodInfraContainer types.UnmarshallableString
+	IP                         net.IP
+	K8S_POD_NAME               types.UnmarshallableString // nolint: golint
+	K8S_POD_NAMESPACE          types.UnmarshallableString // nolint: golint
+	K8S_POD_INFRA_CONTAINER_ID types.UnmarshallableString // nolint: golint
 }
 
 func setupRedirect(netns string, ports []string) error {
@@ -182,7 +185,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if err := types.LoadArgs(args.Args, &k8sArgs); err != nil {
 		return err
 	}
-	logrus.Infof("Getting WEP identifiers with arguments: %s", args.Args)
+	logrus.Infof("Getting identifiers with arguments: %s", args.Args)
 	logrus.Infof("Loaded k8s arguments: %v", k8sArgs)
 	if conf.Kubernetes.CniBinDir != "" {
 		nsSetupBinDir = conf.Kubernetes.CniBinDir
@@ -191,15 +194,15 @@ func cmdAdd(args *skel.CmdArgs) error {
 	var logger *logrus.Entry
 	logger = logrus.WithFields(logrus.Fields{
 		"ContainerID": args.ContainerID,
-		"Pod":         string(k8sArgs.K8sPodName),
-		"Namespace":   string(k8sArgs.K8sPodNamespace),
+		"Pod":         string(k8sArgs.K8S_POD_NAME),
+		"Namespace":   string(k8sArgs.K8S_POD_NAMESPACE),
 	})
 
 	// Check if the workload is running under Kubernetes.
-	if string(k8sArgs.K8sPodNamespace) != "" && string(k8sArgs.K8sPodName) != "" {
+	if string(k8sArgs.K8S_POD_NAMESPACE) != "" && string(k8sArgs.K8S_POD_NAME) != "" {
 		excludePod := false
 		for _, excludeNs := range conf.Kubernetes.ExcludeNamespaces {
-			if string(k8sArgs.K8sPodNamespace) == excludeNs {
+			if string(k8sArgs.K8S_POD_NAMESPACE) == excludeNs {
 				excludePod = true
 				break
 			}
@@ -210,7 +213,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 				return err
 			}
 			logrus.WithField("client", client).Debug("Created Kubernetes client")
-			containers, _, _, ports, k8sErr := GetK8sPodInfo(client, string(k8sArgs.K8sPodName), string(k8sArgs.K8sPodNamespace))
+			containers, _, annotations, ports, k8sErr := GetK8sPodInfo(client, string(k8sArgs.K8S_POD_NAME), string(k8sArgs.K8S_POD_NAMESPACE))
 			if k8sErr != nil {
 				logger.Warnf("Error geting Pod data %v", k8sErr)
 			}
@@ -221,12 +224,24 @@ func cmdAdd(args *skel.CmdArgs) error {
 				logrus.WithFields(logrus.Fields{
 					"ContainerID": args.ContainerID,
 					"netns":       args.Netns,
-					"pod":         string(k8sArgs.K8sPodName),
-					"Namespace":   string(k8sArgs.K8sPodNamespace),
+					"pod":         string(k8sArgs.K8S_POD_NAME),
+					"Namespace":   string(k8sArgs.K8S_POD_NAMESPACE),
 					"ports":       ports,
+					"annotations": annotations,
 				}).Infof("Updating iptables redirect for Istio proxy")
-
-				_ = setupRedirect(args.Netns, ports)
+				if val, ok := annotations[injectAnnotationKey]; ok {
+					logrus.Infof("Pod %s contains inject annotation: %s", string(k8sArgs.K8S_POD_NAME), val)
+					if b, err := strconv.ParseBool(val); err == nil {
+						if !b {
+							logrus.Infof("Pod excluded due to annotations")
+							excludePod = true
+						}
+					}
+				}
+				if !excludePod {
+					logrus.Infof("setting up redirect")
+					_ = setupRedirect(args.Netns, ports)
+				}
 			}
 			//}
 			//}

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 )
 
+// Validate k8sArgs struct works for unmarshalling kubelet args
 func TestLoadArgs(t *testing.T) {
 	kubeletArgs := "IgnoreUnknown=1;K8S_POD_NAMESPACE=istio-system;" +
 		"K8S_POD_NAME=istio-sidecar-injector-8489cf78fb-48pvg;" +

--- a/cmd/istio-cni/main_test.go
+++ b/cmd/istio-cni/main_test.go
@@ -1,0 +1,39 @@
+// Copyright 2018 Istio authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+func TestLoadArgs(t *testing.T) {
+	kubeletArgs := "IgnoreUnknown=1;K8S_POD_NAMESPACE=istio-system;" +
+		"K8S_POD_NAME=istio-sidecar-injector-8489cf78fb-48pvg;" +
+		"K8S_POD_INFRA_CONTAINER_ID=3c41e946cf17a32760ff86940a73b06982f1815e9083cf2f4bfccb9b7605f326"
+
+	k8sArgs := K8sArgs{}
+	if err := types.LoadArgs(kubeletArgs, &k8sArgs); err != nil {
+		t.Errorf("LoadArgs failed with error: %v", err)
+		t.Fail()
+	}
+	t.Logf("LoadArgs didn't fail, result %v", k8sArgs)
+	if string(k8sArgs.K8S_POD_NAMESPACE) == "" || string(k8sArgs.K8S_POD_NAME) == "" {
+		t.Errorf("LoadArgs didn't convert args properly, K8S_POD_NAME=\"%s\";K8S_POD_NAMESPACE=\"%s\"",
+			string(k8sArgs.K8S_POD_NAME), string(k8sArgs.K8S_POD_NAMESPACE))
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Fix k8sArgs elements to exactly match the kubelet key value pairs in the arg string so unmarshalling works.

- add a test case for checking unmarshalling with a sample kubelet arg string
- Add check for sidecar inject disable annotation to not do redirect (set by Istio control-plane pods)
- Changes to .circleci/config.yaml match istio/istio for setting up go 1.10 in the VM

Signed-off-by: Tim Swanson <tiswanso@cisco.com>

Closes: #35 